### PR TITLE
Add support for pixel is point convention

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,3 +26,11 @@ def zmap_object(tmpdir):
     x.write(z_text)
     z_obj = ZMAPGrid(x.strpath)
     yield z_obj
+
+
+@pytest.fixture
+def zmap_object_pixel_is_point(tmpdir):
+    x = tmpdir.join("test.dat")
+    x.write(z_text)
+    z_obj = ZMAPGrid(x.strpath, pixel_is_point=True)
+    yield z_obj

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -13,6 +13,15 @@ def test_export_to_csv(zmap_object, tmpdir):
     assert lines[1] == "0.0,300.0,nan\n"
 
 
+def test_export_to_csv_pixel_is_point(zmap_object_pixel_is_point, tmpdir):
+    x = tmpdir.join("output.csv")
+    zmap_object_pixel_is_point.to_csv(x.strpath)
+    lines = x.readlines()
+    assert len(lines) == 25
+    assert lines[0] == "# X,Y,Z\n"
+    assert lines[1] == "25.0,275.0,nan\n"
+
+
 def test_export_to_geojson(zmap_object, tmpdir):
     x = tmpdir.join("output.json")
     zmap_object.to_geojson(x.strpath)
@@ -23,12 +32,30 @@ def test_export_to_geojson(zmap_object, tmpdir):
     assert [0.0, 60.0, 88.0] in d.get("coordinates")
 
 
+def test_export_to_geojson_pixel_is_point(zmap_object_pixel_is_point, tmpdir):
+    x = tmpdir.join("output.json")
+    zmap_object_pixel_is_point.to_geojson(x.strpath)
+    d = json.load(x)
+    assert sorted(list(d.keys())) == ["coordinates", "type"]
+    assert d.get("type") == "MultiPoint"
+    assert len(d.get("coordinates")) == 24
+    assert [25.0, 175.0, 3.0] in d.get("coordinates")
+
+
 def test_export_to_wkt(zmap_object, tmpdir):
     x = tmpdir.join("output.wkt")
     zmap_object.to_wkt(x.strpath)
     with open(x.strpath) as f:
         line = f.readline()
     assert line.startswith("MULTIPOINT ((0.0000000 300.0000000 nan),")
+
+
+def test_export_to_wkt_pixel_is_point(zmap_object_pixel_is_point, tmpdir):
+    x = tmpdir.join("output.wkt")
+    zmap_object_pixel_is_point.to_wkt(x.strpath)
+    with open(x.strpath) as f:
+        line = f.readline()
+    assert line.startswith("MULTIPOINT ((25.0000000 275.0000000 nan),")
 
 
 def test_export_to_wkt_with_precision(zmap_object, tmpdir):

--- a/zmapio/zmap.py
+++ b/zmapio/zmap.py
@@ -23,6 +23,7 @@ class ZMAPGrid(object):
         min_y=None,
         max_y=None,
         z_values=None,
+        pixel_is_point=False,
         **kwargs
     ):
         self.comments = comments
@@ -39,6 +40,7 @@ class ZMAPGrid(object):
         self.max_x = max_x
         self.min_y = min_y
         self.max_y = max_y
+        self.pixel_is_point = pixel_is_point
 
         if file_ref:
             x, y, z = self.read(file_ref, **kwargs)
@@ -80,8 +82,17 @@ class ZMAPGrid(object):
 
         z[z == self.null_value] = np.nan
         z = z.reshape((self.no_cols, self.no_rows))
-        x = np.linspace(self.min_x, self.max_x, self.no_cols)
-        y = np.linspace(self.max_y, self.min_y, self.no_rows)
+        if self.pixel_is_point:
+            # get cell size
+            dx = (self.max_x - self.min_x) / self.no_cols
+            dy = (self.max_y - self.min_y) / self.no_rows
+            x = np.linspace(self.min_x + (dx / 2), self.max_x - (dx / 2), self.no_cols)
+            y = np.linspace(self.max_y - (dy / 2), self.min_y + (dy / 2), self.no_rows)
+
+        else:
+            x = np.linspace(self.min_x, self.max_x, self.no_cols)
+            y = np.linspace(self.max_y, self.min_y, self.no_rows)
+
         x, y = np.meshgrid(x, y)
 
         return x, y, z


### PR DESCRIPTION
Hi @jscotchman, 

Please check this PR ... I added `pixel_is_point` option to support this convention. 

```python
z_obj = ZMAPGrid(x.strpath, pixel_is_point=True)
```
result:

<img width="631" alt="image" src="https://user-images.githubusercontent.com/19528166/169088274-453c444e-ff3a-43b9-a1c9-8bf66e69792b.png">
